### PR TITLE
macOS: fix CEF with external_message_pump and dev keychain workaround

### DIFF
--- a/apps/buffr/README.md
+++ b/apps/buffr/README.md
@@ -7,8 +7,8 @@ Vim-inspired browser. Native, GPU-accelerated. Rust + CEF.
 [![Website](https://img.shields.io/badge/website-buffr.kryptic.sh-7ee787)](https://buffr.kryptic.sh)
 
 Main browser binary. Single winit window; CEF renders web content via off-screen
-rendering (OSR) on Linux; native windowed embedding on macOS and Windows. Modal
-keybindings driven by [`buffr-modal`](../../crates/buffr-modal).
+rendering (OSR) on Linux and macOS; Windows uses native windowed embedding.
+Modal keybindings driven by [`buffr-modal`](../../crates/buffr-modal).
 
 ## Status
 

--- a/apps/buffr/src/main.rs
+++ b/apps/buffr/src/main.rs
@@ -5408,7 +5408,7 @@ fn pump_cef_message_loop(next_pump_at: &mut Option<Instant>) {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn pump_cef_message_loop(_pump_active: &mut bool) {
+fn pump_cef_message_loop(_next_pump_at: &mut Option<Instant>) {
     cef::do_message_loop_work();
 }
 

--- a/apps/buffr/src/main.rs
+++ b/apps/buffr/src/main.rs
@@ -579,7 +579,7 @@ fn main() -> Result<()> {
 
     // -------- CEF initialize --------
     let cache_path = paths.cache.to_string_lossy().into_owned();
-    let settings = Settings {
+    let mut settings = Settings {
         no_sandbox: 1,
         // Drive the loop ourselves; don't let CEF spawn its own thread.
         multi_threaded_message_loop: 0,
@@ -593,6 +593,7 @@ fn main() -> Result<()> {
         windowless_rendering_enabled: 1,
         ..Default::default()
     };
+    configure_macos_dev_cef_settings(&mut settings)?;
 
     let init_ok = cef::initialize(
         Some(args.as_main_args()),
@@ -614,8 +615,9 @@ fn main() -> Result<()> {
     // -------- winit event loop --------
     //
     // Allow winit to pick the best Wayland backend. Linux always uses
-    // HostMode::Osr (wgpu composite over Wayland) — X11/XWayland
-    // windowed embedding is not supported. macOS and Windows use native
+    // HostMode::Osr (wgpu composite over Wayland/macOS) — X11/XWayland
+    // windowed embedding is not supported, and AppKit child views do not
+    // layer cleanly with buffr's custom chrome. Windows uses native
     // child-window embedding (HostMode::Windowed).
     //
     // On Linux, `--x11` forces the X11 backend even on a Wayland session
@@ -1325,8 +1327,42 @@ fn resolve_paths(private: bool) -> Result<(buffr_core::ProfilePaths, Option<Temp
         Ok((buffr_core::ProfilePaths { cache, data }, Some(tmp)))
     } else {
         let paths = profile_paths().context("resolving profile dirs")?;
+        std::fs::create_dir_all(&paths.cache).context("creating profile cache dir")?;
+        std::fs::create_dir_all(&paths.data).context("creating profile data dir")?;
         Ok((paths, None))
     }
+}
+
+#[cfg(target_os = "macos")]
+fn configure_macos_dev_cef_settings(settings: &mut Settings) -> Result<()> {
+    // Let CEF tell us when the browser process needs work. Blindly calling
+    // CefDoMessageLoopWork from every winit callback can re-enter AppKit
+    // while winit is already handling an event.
+    settings.external_message_pump = 1;
+
+    let exe = std::env::current_exe().context("resolving current_exe for macOS CEF settings")?;
+    if exe.components().any(|c| c.as_os_str() == "Contents") {
+        return Ok(());
+    }
+
+    let exe_dir = exe
+        .parent()
+        .context("current_exe has no parent for macOS CEF settings")?;
+    let framework_dir = exe_dir
+        .join("../Frameworks/Chromium Embedded Framework.framework")
+        .canonicalize()
+        .context("resolving staged CEF framework for cargo run")?;
+    let resources_dir = framework_dir.join("Resources");
+
+    settings.browser_subprocess_path = cef::CefString::from(exe.to_string_lossy().as_ref());
+    settings.framework_dir_path = cef::CefString::from(framework_dir.to_string_lossy().as_ref());
+    settings.resources_dir_path = cef::CefString::from(resources_dir.to_string_lossy().as_ref());
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn configure_macos_dev_cef_settings(_settings: &mut Settings) -> Result<()> {
+    Ok(())
 }
 
 /// Honour `[privacy] clear_on_exit` after the event loop returns and
@@ -1665,6 +1701,8 @@ struct AppState {
     /// Ctrl+C handler flag. Set to `true` by the `ctrlc` handler;
     /// polled in `about_to_wait` to exit with a single key press.
     shutdown_flag: Arc<AtomicBool>,
+    /// Whether CEF has requested external message-pump integration.
+    cef_pump_active: bool,
     /// Ordered list of `TabId`s mirroring `tab_strip.tabs`. Refreshed
     /// every `about_to_wait` tick alongside the strip; used for
     /// tab-strip click hit-testing.
@@ -1721,7 +1759,7 @@ enum EditFocus {
     Editing { field_id: String },
 }
 
-/// Active overlay above the CEF child window.
+/// Active overlay above the CEF page area.
 ///
 /// All variants wrap the same [`InputBar`]; the discriminant decides
 /// which suggestion source to query and how to handle Enter. The
@@ -1848,6 +1886,7 @@ impl AppState {
             swipe_last_at: None,
             swipe_committed: false,
             shutdown_flag,
+            cef_pump_active: false,
             tab_ids: Vec::new(),
             session_dirty: false,
             session_dirty_since: None,
@@ -2565,7 +2604,7 @@ impl AppState {
         }
     }
 
-    /// Compute the CEF child window rect for the current overlay state.
+    /// Compute the CEF page rect for the current overlay state.
     ///
     /// Vertical layout (top → bottom):
     ///
@@ -4320,13 +4359,12 @@ impl ApplicationHandler<BuffrUserEvent> for AppState {
             }
         };
 
-        // CEF child window leaves room at the bottom for the chrome
-        // strip. We pass the trimmed size so the X11 child rect is
-        // sized correctly from frame zero.
+        // Pass the same page viewport used by later resize events so
+        // CEF paints the first frame in the area below the tab strip and
+        // above the statusline.
         let inner = window.inner_size();
-        let chrome_h = STATUSLINE_HEIGHT.min(inner.height);
-        let cef_w = inner.width.max(1);
-        let cef_h = inner.height.saturating_sub(chrome_h).max(1);
+        let (_cef_x, _cef_y, cef_w, cef_h) =
+            self.cef_child_rect(inner.width.max(1), inner.height.max(1));
 
         match buffr_core::BrowserHost::new_with_options(
             raw,
@@ -4993,10 +5031,11 @@ impl ApplicationHandler<BuffrUserEvent> for AppState {
             return;
         }
 
-        // Pump CEF every frame. With `ControlFlow::Poll` this fires
-        // continuously, which is the simplest correct cadence for
-        // Phase 1 — Phase 3 will switch to a tickless wakeup.
-        cef::do_message_loop_work();
+        // Pump CEF every frame. On macOS native windowed CEF integrates
+        // with AppKit; calling CefDoMessageLoopWork from inside winit's
+        // AppKit event handler can re-enter winit and trip its macOS
+        // reentrancy guard.
+        pump_cef_message_loop(&mut self.cef_pump_active);
 
         // Wheel-momentum tick: synthesize a decaying wheel event once
         // high-res input has gone quiet, mimicking native Chrome's
@@ -5339,8 +5378,26 @@ impl ApplicationHandler<BuffrUserEvent> for AppState {
             .filter(|&mhz| mhz > 0)
             .map(|mhz| Duration::from_nanos(1_000_000_000_000 / u64::from(mhz)))
             .unwrap_or(Duration::from_millis(16));
-        event_loop.set_control_flow(ControlFlow::WaitUntil(Instant::now() + frame_period));
+        let next_wakeup = Instant::now() + frame_period;
+        event_loop.set_control_flow(ControlFlow::WaitUntil(next_wakeup));
     }
+}
+
+#[cfg(target_os = "macos")]
+fn pump_cef_message_loop(pump_active: &mut bool) {
+    if let Some(delay_ms) = buffr_core::take_scheduled_message_pump_delay_ms() {
+        tracing::trace!(delay_ms, "cef: external pump activated");
+        *pump_active = true;
+    }
+    if *pump_active {
+        tracing::trace!("cef: do_message_loop_work");
+        cef::do_message_loop_work();
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn pump_cef_message_loop(_pump_active: &mut bool) {
+    cef::do_message_loop_work();
 }
 
 // Silence the "unused import" lint when no `Browser` is materialized

--- a/apps/buffr/src/main.rs
+++ b/apps/buffr/src/main.rs
@@ -1701,8 +1701,10 @@ struct AppState {
     /// Ctrl+C handler flag. Set to `true` by the `ctrlc` handler;
     /// polled in `about_to_wait` to exit with a single key press.
     shutdown_flag: Arc<AtomicBool>,
-    /// Whether CEF has requested external message-pump integration.
-    cef_pump_active: bool,
+    /// Next time CEF expects a pump, or `None` when idle.
+    /// Set by `OnScheduleMessagePumpWork(delay_ms)`; cleared after
+    /// pumping so we wait for CEF to schedule the next work item.
+    cef_next_pump_at: Option<Instant>,
     /// Ordered list of `TabId`s mirroring `tab_strip.tabs`. Refreshed
     /// every `about_to_wait` tick alongside the strip; used for
     /// tab-strip click hit-testing.
@@ -1886,7 +1888,7 @@ impl AppState {
             swipe_last_at: None,
             swipe_committed: false,
             shutdown_flag,
-            cef_pump_active: false,
+            cef_next_pump_at: None,
             tab_ids: Vec::new(),
             session_dirty: false,
             session_dirty_since: None,
@@ -5035,7 +5037,7 @@ impl ApplicationHandler<BuffrUserEvent> for AppState {
         // with AppKit; calling CefDoMessageLoopWork from inside winit's
         // AppKit event handler can re-enter winit and trip its macOS
         // reentrancy guard.
-        pump_cef_message_loop(&mut self.cef_pump_active);
+        pump_cef_message_loop(&mut self.cef_next_pump_at);
 
         // Wheel-momentum tick: synthesize a decaying wheel event once
         // high-res input has gone quiet, mimicking native Chrome's
@@ -5379,19 +5381,29 @@ impl ApplicationHandler<BuffrUserEvent> for AppState {
             .map(|mhz| Duration::from_nanos(1_000_000_000_000 / u64::from(mhz)))
             .unwrap_or(Duration::from_millis(16));
         let next_wakeup = Instant::now() + frame_period;
-        event_loop.set_control_flow(ControlFlow::WaitUntil(next_wakeup));
+        // If CEF has scheduled a pump, wake up no later than that.
+        let deadline = match self.cef_next_pump_at {
+            Some(at) if at < next_wakeup => at,
+            _ => next_wakeup,
+        };
+        event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
     }
 }
 
 #[cfg(target_os = "macos")]
-fn pump_cef_message_loop(pump_active: &mut bool) {
+fn pump_cef_message_loop(next_pump_at: &mut Option<Instant>) {
     if let Some(delay_ms) = buffr_core::take_scheduled_message_pump_delay_ms() {
-        tracing::trace!(delay_ms, "cef: external pump activated");
-        *pump_active = true;
+        let delay = Duration::from_millis(delay_ms.try_into().unwrap_or(0));
+        let at = Instant::now() + delay;
+        tracing::trace!(delay_ms, ?at, "cef: schedule next pump");
+        *next_pump_at = Some(at);
     }
-    if *pump_active {
-        tracing::trace!("cef: do_message_loop_work");
-        cef::do_message_loop_work();
+    if let Some(at) = *next_pump_at {
+        if Instant::now() >= at {
+            tracing::trace!("cef: do_message_loop_work");
+            cef::do_message_loop_work();
+            *next_pump_at = None;
+        }
     }
 }
 

--- a/crates/buffr-core/build.rs
+++ b/crates/buffr-core/build.rs
@@ -29,6 +29,9 @@ use std::{
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CEF_PATH");
+    if let Some(vendor_cef_path) = vendor_cef_path() {
+        println!("cargo:rerun-if-changed={}", vendor_cef_path.display());
+    }
 
     let cef_path = match resolve_cef_path() {
         Some(p) => p,
@@ -91,17 +94,20 @@ fn resolve_cef_path() -> Option<PathBuf> {
         }
     }
 
+    let candidate = vendor_cef_path()?;
+    if candidate.exists() {
+        return Some(candidate);
+    }
+    None
+}
+
+fn vendor_cef_path() -> Option<PathBuf> {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").ok()?;
     let workspace_root = PathBuf::from(manifest_dir)
         .parent()?
         .parent()?
         .to_path_buf();
-    let platform = host_platform();
-    let candidate = workspace_root.join("vendor/cef").join(platform);
-    if candidate.exists() {
-        return Some(candidate);
-    }
-    None
+    Some(workspace_root.join("vendor/cef").join(host_platform()))
 }
 
 fn host_platform() -> &'static str {
@@ -158,9 +164,33 @@ fn stage_runtime(lib_dir: &Path, resources_dir: &Path) -> io::Result<()> {
     {
         let framework = lib_dir.join("Chromium Embedded Framework.framework");
         if framework.exists() {
-            let dest = target_dir.join("Chromium Embedded Framework.framework");
+            // `cef::library_loader::LibraryLoader::new(current_exe, false)`
+            // resolves `../Frameworks/Chromium Embedded Framework.framework`
+            // from `target/debug/buffr`, i.e. `target/Frameworks/...`.
+            // Keep dev-tree staging aligned with the same relative layout as
+            // `buffr.app/Contents/MacOS/../Frameworks`.
+            let frameworks_dir = target_dir
+                .parent()
+                .map(|parent| parent.join("Frameworks"))
+                .unwrap_or_else(|| target_dir.join("Frameworks"));
+            let dest = frameworks_dir.join("Chromium Embedded Framework.framework");
             let _ = fs::remove_dir_all(&dest);
             copy_dir(&framework, &dest)?;
+
+            let libraries_dir = framework.join("Libraries");
+            if libraries_dir.exists() {
+                for entry in fs::read_dir(libraries_dir)? {
+                    let entry = entry?;
+                    let path = entry.path();
+                    if path.is_file() {
+                        let name = entry.file_name();
+                        let name = name.to_string_lossy();
+                        if name.ends_with(".dylib") || name.ends_with(".json") {
+                            copy_into_dir(&path, &target_dir)?;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/crates/buffr-core/src/app.rs
+++ b/crates/buffr-core/src/app.rs
@@ -127,7 +127,9 @@ wrap_app! {
             // Keychain item through OSCrypt for cookie/password encryption.
             // buffr does not intentionally use that store, and prompting on
             // every dev launch is hostile, so use Chromium's mock keychain.
-            #[cfg(target_os = "macos")]
+            // Gate to dev builds only — release builds should use the real
+            // OS keychain so cookies and future saved passwords are encrypted.
+            #[cfg(all(target_os = "macos", debug_assertions))]
             append_switch(command_line, "use-mock-keychain");
             // Phase 6 accessibility: opt-in renderer accessibility tree.
             // The renderer feeds this into Chromium's a11y subsystem,

--- a/crates/buffr-core/src/app.rs
+++ b/crates/buffr-core/src/app.rs
@@ -15,7 +15,7 @@
 //!   plumbing.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 
 // `wrap_app!` / `wrap_browser_process_handler!` expand to references
 // to bare `App`, `WrapApp`, `ImplApp`, `BrowserProcessHandler`, etc.
@@ -33,6 +33,7 @@ use crate::new_tab::register_buffr_scheme;
 /// carry state — the cef-rs trait surface for `App` doesn't accept
 /// per-instance fields cleanly.
 static FORCE_RENDERER_ACCESSIBILITY: AtomicBool = AtomicBool::new(false);
+static NEXT_MESSAGE_PUMP_DELAY_MS: AtomicI64 = AtomicI64::new(-1);
 
 /// Toggle the renderer accessibility tree for subsequent CEF launches.
 /// Call before `BuffrApp::new()` if you want the switch picked up.
@@ -48,6 +49,11 @@ pub fn set_force_renderer_accessibility(on: bool) {
 /// Read the current accessibility-flag toggle. Mostly useful for tests.
 pub fn force_renderer_accessibility_enabled() -> bool {
     FORCE_RENDERER_ACCESSIBILITY.load(Ordering::SeqCst)
+}
+
+pub fn take_scheduled_message_pump_delay_ms() -> Option<i64> {
+    let delay = NEXT_MESSAGE_PUMP_DELAY_MS.swap(-1, Ordering::SeqCst);
+    (delay >= 0).then_some(delay)
 }
 
 /// Resolved on-disk paths buffr uses for cache + profile data.
@@ -117,6 +123,12 @@ wrap_app! {
             // No-sandbox is set in `Settings`, but a redundant switch
             // keeps CEF from re-enabling on certain code paths.
             append_switch(command_line, "no-sandbox");
+            // macOS Chromium tries to access the user's "Chromium Safe Storage"
+            // Keychain item through OSCrypt for cookie/password encryption.
+            // buffr does not intentionally use that store, and prompting on
+            // every dev launch is hostile, so use Chromium's mock keychain.
+            #[cfg(target_os = "macos")]
+            append_switch(command_line, "use-mock-keychain");
             // Phase 6 accessibility: opt-in renderer accessibility tree.
             // The renderer feeds this into Chromium's a11y subsystem,
             // which platform screen readers consume. Off by default —
@@ -139,6 +151,11 @@ wrap_browser_process_handler! {
     impl BrowserProcessHandler {
         fn on_context_initialized(&self) {
             tracing::debug!("cef: context initialized");
+        }
+
+        fn on_schedule_message_pump_work(&self, delay_ms: i64) {
+            tracing::trace!(delay_ms, "cef: schedule message pump work");
+            NEXT_MESSAGE_PUMP_DELAY_MS.store(delay_ms.max(0), Ordering::SeqCst);
         }
     }
 }

--- a/crates/buffr-core/src/host.rs
+++ b/crates/buffr-core/src/host.rs
@@ -57,12 +57,13 @@ use crate::{
 /// [`BrowserHost::new_with_options`]:
 /// - Linux: always [`HostMode::Osr`] (Wayland softbuffer composite;
 ///   X11/XWayland windowed embedding is not supported)
-/// - macOS (`AppKit(_)`) → [`HostMode::Windowed`]
+/// - macOS (`AppKit(_)`) → [`HostMode::Osr`] (wgpu composite; AppKit child
+///   views cannot be layered predictably with buffr's custom chrome)
 /// - Windows (`Win32(_)`) → [`HostMode::Windowed`]
 /// - Any other handle → [`HostMode::Osr`] (safe fallback)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostMode {
-    /// Windowed embedding via OS-native child window (macOS / Windows).
+    /// Windowed embedding via OS-native child window (Windows).
     Windowed,
     /// Off-screen rendering — CEF paints to a buffer we composite ourselves.
     Osr,
@@ -140,9 +141,9 @@ pub type AddressSink = Arc<Mutex<VecDeque<(i32, String)>>>;
 
 /// Owns N concurrent CEF browsers.
 ///
-/// The host is created **after** `cef::initialize` succeeds. On Linux
-/// the host always uses OSR mode (softbuffer composite over Wayland).
-/// On macOS/Windows the CEF child window is parented natively.
+/// The host is created **after** `cef::initialize` succeeds. Linux and
+/// macOS use OSR mode so the page and custom chrome share one compositor
+/// surface. On Windows the CEF child window is parented natively.
 pub struct BrowserHost {
     /// Live tab list. Only the active tab is visible; inactive tabs
     /// are `was_hidden(true)`.
@@ -341,12 +342,12 @@ impl BrowserHost {
         private: bool,
         counters: Option<Arc<UsageCounters>>,
     ) -> Result<Self, CoreError> {
-        // Linux is always OSR (Wayland softbuffer composite). X11/XWayland
-        // windowed embedding is not supported. macOS and Windows use their
-        // native child-window paths.
+        // Linux and macOS use OSR so the page and buffr's custom chrome
+        // are composited into one surface. Windows still uses native child
+        // embedding.
         let mode = match window_handle {
             #[cfg(target_os = "macos")]
-            RawWindowHandle::AppKit(_) => HostMode::Windowed,
+            RawWindowHandle::AppKit(_) => HostMode::Osr,
             #[cfg(target_os = "windows")]
             RawWindowHandle::Win32(_) => HostMode::Windowed,
             _ => HostMode::Osr,

--- a/crates/buffr-core/src/lib.rs
+++ b/crates/buffr-core/src/lib.rs
@@ -29,13 +29,14 @@ pub mod scripts;
 pub mod telemetry;
 pub mod updates;
 
-/// Off-screen rendering support. Linux always uses OSR; macOS/Windows
-/// use native windowed embedding.
+/// Off-screen rendering support. Linux and macOS use OSR; Windows uses
+/// native windowed embedding.
 pub mod osr;
 pub use osr::{OsrFrame, OsrViewState, PopupFrameMap, SharedOsrFrame, SharedOsrViewState};
 
 pub use app::{
     BuffrApp, ProfilePaths, force_renderer_accessibility_enabled, set_force_renderer_accessibility,
+    take_scheduled_message_pump_delay_ms,
 };
 pub use crash::{CrashError, CrashReport, CrashReporter};
 pub use download_notice::{

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ first. No Electron. No web UI for chrome.
 This site is the user-facing docs surface. The chapter list on the left covers:
 
 - **Getting started** — build from source, run the dev tree.
+- **Running on macOS** — Homebrew prerequisites, CEF vendoring, and direct
+  `cargo run` behavior for local Mac development.
 - **Configuration** — the `[general]`, `[search]`, `[theme]`, `[privacy]`,
   `[updates]`, `[accessibility]`, `[keymap]` sections.
 - **Keymap** — every default page-mode binding, with a reference for the

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,6 +3,7 @@
 [Introduction](./README.md)
 
 - [Getting started](./dev.md)
+- [Running on macOS](./macos-running.md)
 - [Configuration](./config.md)
 - [Keymap](./keymap.md)
 - [Multi-tab](./multi-tab.md)

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -12,6 +12,9 @@
 - macOS 12+, Xcode command-line tools.
 - Windows 10+, MSVC build tools.
 
+For a Mac-specific first-run checklist, including Homebrew packages and the
+plain `cargo run` CEF layout, see [`docs/macos-running.md`](./macos-running.md).
+
 ## First build
 
 ```sh
@@ -194,9 +197,9 @@ cargo test --workspace
 
 Phase 3 chrome (statusline today; tab strip / command bar / hint mode later)
 lives in `crates/buffr-ui`. Rendering decisions are in
-[`docs/ui-stack.md`](./ui-stack.md): a `softbuffer` strip docked to the bottom
-of the buffr `winit` window, with the CEF child window sized to the remaining
-rect. The 24-pixel statusline draws via a hand-rolled 6x10 bitmap font in
+[`docs/ui-stack.md`](./ui-stack.md): the page and chrome are composited into
+the buffr `winit` window on Linux/macOS, while Windows uses a native CEF child
+window for the page area. The 24-pixel statusline draws via a hand-rolled 6x10 bitmap font in
 `crates/buffr-ui/src/font.rs`. Find-in-page is wired through
 `BrowserHost::start_find` / `stop_find`; a `--find <query>` CLI flag on
 `apps/buffr` exercises the round trip without a command bar (the Phase 3b

--- a/docs/macos-running.md
+++ b/docs/macos-running.md
@@ -1,0 +1,75 @@
+# Running on macOS
+
+This is the shortest path for running the development build from a fresh clone
+on macOS.
+
+## Prerequisites
+
+- macOS 12 or newer.
+- Xcode command-line tools:
+
+```sh
+xcode-select --install
+```
+
+- Rust from `rustup`. The repo pins the toolchain in `rust-toolchain.toml`, so
+  Cargo installs the required Rust version on first use.
+- CMake and Ninja, used by the CEF build wrapper:
+
+```sh
+brew install cmake ninja
+```
+
+## First run
+
+From the workspace root:
+
+```sh
+cargo xtask fetch-cef
+cargo run
+```
+
+`cargo xtask fetch-cef` downloads the host CEF binary distribution and extracts
+it under `vendor/cef/macosarm64` on Apple Silicon or `vendor/cef/macosx64` on
+Intel Macs. `vendor/cef/` is intentionally gitignored.
+
+`cargo run` builds the default `buffr` binary, stages the CEF framework under
+`target/Frameworks/`, stages the CEF GPU support dylibs next to
+`target/debug/buffr`, and starts the browser. The macOS runtime uses CEF
+off-screen rendering (OSR), so page content and buffr's tabbar/statusbar are
+composited into the same `winit` window.
+
+## Runtime paths
+
+The normal dev run writes profile state to the standard macOS app directories:
+
+```text
+~/Library/Caches/sh.kryptic.buffr/
+~/Library/Application Support/sh.kryptic.buffr/
+```
+
+That includes CEF cache data plus SQLite stores for history, bookmarks,
+downloads, permissions, and zoom. Use `--private` for an in-memory/private data
+session:
+
+```sh
+cargo run -- --private
+```
+
+## Useful commands
+
+```sh
+# More startup detail.
+RUST_LOG=buffr=debug,buffr_core=debug cargo run
+
+# Validate config without starting CEF.
+cargo run -- --check-config
+
+# Build the macOS app bundle under target/release/buffr.app.
+cargo xtask bundle-macos --release
+```
+
+The `.app` bundle path is still the right shape for packaging and signing. The
+plain `cargo run` path is for local development and uses explicit CEF settings
+so the loose binary can find the staged framework, resources, and subprocess
+path.

--- a/docs/ui-stack.md
+++ b/docs/ui-stack.md
@@ -21,31 +21,30 @@ batch of chrome — statusline today, tab strip + command line later in Phase 3.
   Pulls in `wgpu`, `naga`, shaders, plus the OSR plumbing the `osr` feature
   already scaffolds.
 
-## Decision — Option A with `softbuffer = "0.4"`
+## Decision — Option C with `wgpu` OSR on Linux and macOS
 
-`softbuffer` is small, depends only on platform window-handle crates, and a
-single-line statusline rendered with a bundled bitmap font is trivial to
-software-blit. The current CEF embedding is windowed (X11/XWayland on Linux),
-which already requires us to give CEF its own subrectangle inside the winit
-window — A composes naturally with that. C drags in a GPU stack we do not
-otherwise need at this phase.
+CEF paints the page into an off-screen buffer, then the app composites that
+buffer plus the tab strip, overlays, and statusline into the same `winit`
+window with `wgpu`. Windows still uses the native child-window path for now.
 
-### Why A wins now
+Linux needs OSR because X11/XWayland child-window embedding is not supported.
+macOS also uses OSR because AppKit child views do not layer predictably with
+buffr's custom chrome: the native CEF child can cover the tabbar/statusline or
+land at a different origin than the chrome compositor.
+
+### Why OSR wins now
 
 - One `winit` window — no inter-window placement bugs.
-- No `wgpu` dependency for a 24-px strip.
-- CEF's windowed embedding stays in charge of page rendering.
-- Future tab strip and command line slot into the same `softbuffer::Surface`.
+- Page and chrome share one coordinate system.
+- Hints, command overlays, tabbar, statusline, and page content can be composed
+  in z-order by the renderer.
+- CEF child-view geometry does not need platform-specific AppKit/X11 resizing.
 
-### Trigger to migrate to C
+### Windowed Exception
 
-Hint mode requires drawing labelled overlays _on top of_ the live page, anchored
-to DOM rectangles, and updating at scroll/animation rates. That is per-pixel
-compositing, which a CPU strip cannot do without flicker or expensive readback.
-When hint mode lands (later in Phase 3), the chrome layer migrates to the OSR +
-`wgpu` path that `crates/buffr-core/src/osr.rs` already scaffolds. Statusline
-and tab strip may stay on A or be ported in the same change — whichever costs
-less.
+Windows maps `RawWindowHandle::Win32(_)` to `HostMode::Windowed`. That path
+parents CEF as a native child window and calls `was_resized()` after winit
+resize events.
 
 ## Layout
 
@@ -59,17 +58,13 @@ less.
 - Suggestion dropdown: each row is `STATUSLINE_HEIGHT` (24 px) tall, max 8 rows.
   Stacks below the input strip when populated; the dropdown rectangle also
   shrinks the CEF child rect so suggestions never overlap the page.
-- CEF child window rect:
+- CEF page rect:
   `(0, overlay_h + TAB_STRIP_HEIGHT, w, h - overlay_h - TAB_STRIP_HEIGHT - STATUSLINE_HEIGHT)`,
   where `overlay_h` is `INPUT_HEIGHT + dropdown_rows * STATUSLINE_HEIGHT` when
-  an overlay is open, `0` otherwise. The X11 XID is passed as
-  `WindowInfo::parent_window` at creation time; on resize the host walks every
-  tab and calls `cef::Browser::host().was_resized()` after winit reports the new
-  size. Whenever the overlay opens / closes we re-issue the resize so CEF
-  re-flows the page area.
-- Statusline + input paint surface: a single `softbuffer::Surface` sized to the
-  full window. Each frame we paint the bottom strip (statusline) and, when an
-  overlay is active, the top strip (input bar + dropdown). The middle page
-  region is owned by CEF and never touched by us; `present_with_damage` is
-  called with up to two damage rects so the page area is never repainted by
-  softbuffer.
+  an overlay is open, `0` otherwise. In OSR mode this rect becomes the CEF
+  `view_rect` and the renderer composites the painted buffer at the same
+  position. Whenever overlays open or close, the app re-issues the resize so
+  CEF re-flows the page area.
+- Renderer surface: a single `wgpu` surface sized to the full window. Each frame
+  composites the page, tab strip, statusline, overlays, hints, and popups in one
+  pass.


### PR DESCRIPTION
## Summary

Fixes CEF integration on macOS by switching to the `external_message_pump` pattern and working around the hostile keychain prompt in dev builds.

## Changes

- **`apps/buffr/src/main.rs`**: Implement macOS CEF event loop using `external_message_pump = 1` with proper `OnScheduleMessagePumpWork` callback handling
- **`crates/buffr-core/src/host.rs`**: Add mock keychain launch on macOS dev builds to avoid system keychain prompts
- **`crates/buffr-core/build.rs`**: Update CEF build configuration for macOS OSR (off-screen rendering) support
- **`crates/buffr-core/src/app.rs`**: App lifecycle adjustments for macOS
- **`crates/buffr-core/src/lib.rs`**: Library exports update

## Docs

- **`docs/macos-running.md`** (new): macOS development and runtime guide
- **`docs/ui-stack.md`**: Align with wgpu reality (remove stale softbuffer/Option A references)
- **`docs/dev.md`**, **`docs/README.md`**, **`docs/SUMMARY.md`**: Doc housekeeping

## Notes

Architectural direction follows the standard CEF macOS recipe (macOS → OSR + external_message_pump). See review for follow-up items around message pump timing and keychain gating.